### PR TITLE
Fix Incorrect BLE MTU Chunking in write()

### DIFF
--- a/src/NuS.cpp
+++ b/src/NuS.cpp
@@ -193,7 +193,14 @@ size_t NordicUARTService::write(const uint8_t *data, size_t size)
 {
    if (pTxCharacteristic)
    {
-      pTxCharacteristic->notify(data, size);
+      uint32_t chunkSize = NimBLEDevice::getMTU();
+      uint32_t offset = 0;
+      while (offset < size)
+      {
+         uint32_t len = (size - offset > chunkSize) ? chunkSize : (size - offset);
+         pTxCharacteristic->notify(data + offset, len);
+         offset += len;
+      }
       return size;
    }
    else
@@ -205,7 +212,7 @@ size_t NordicUARTService::send(const char *str, bool includeNullTerminatingChar)
    if (pTxCharacteristic)
    {
       size_t size = includeNullTerminatingChar ? strlen(str) + 1 : strlen(str);
-      pTxCharacteristic->notify((uint8_t *)str, size);
+      write((uint8_t *)str, size);
       return size;
    }
    else


### PR DESCRIPTION
This PR addresses Issue #14, which reported that the write() method in NuS.cpp does not properly handle BLE MTU chunking. The previous implementation could send data chunks larger than the allowed MTU, potentially causing transmission errors.

Changes:

Updated the write() method to correctly split outgoing data into chunks that do not exceed the current BLE MTU size.
Ensured that each call to notify() only sends a chunk of data within the MTU limit.